### PR TITLE
Fix dangerous query method dep warning

### DIFF
--- a/lib/active_recall/models/deck.rb
+++ b/lib/active_recall/models/deck.rb
@@ -8,10 +8,10 @@ module ActiveRecall
     belongs_to :user, polymorphic: true
     has_many :items, class_name: 'ActiveRecall::Item', dependent: :destroy
 
-    def each(&block)
+    def each
       _items.each do |item|
         if block_given?
-          block.call item
+          yield item
         else
           yield item
         end
@@ -87,11 +87,7 @@ module ActiveRecall
     private
 
     def random_order_function
-      if mysql?
-        'RAND()'
-      else
-        'random()'
-      end
+      Arel.sql(mysql? ? 'RAND()' : 'random()')
     end
 
     def mysql?


### PR DESCRIPTION
DEPRECATION WARNING:
Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "random()".
Non-attribute arguments will be disallowed in Rails 6.0.
This method should not be called with user-provided values, such as request parameters or model attributes.
Known-safe values can be passed by wrapping them in Arel.sql().