### PR TITLE
Allow decks made using single table inheritance

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_recall (1.2.2)
+    active_recall (1.3.0)
       activerecord (>= 5.2.3)
       activesupport (>= 5.2.3)
 

--- a/lib/active_recall/models/item.rb
+++ b/lib/active_recall/models/item.rb
@@ -5,7 +5,6 @@ module ActiveRecall
     self.table_name = 'active_recall_items'
 
     belongs_to :deck
-    belongs_to :source, polymorphic: true
 
     scope :failed, -> { where(['box = ? and last_reviewed is not null', 0]) }
     scope :untested, -> { where(['box = ? and last_reviewed is null', 0]) }
@@ -16,6 +15,10 @@ module ActiveRecall
 
     def self.known(current_time: Time.current)
       where(['box > ? and next_review > ?', 0, current_time])
+    end
+
+    def source
+      source_type.constantize.find(source_id)
     end
 
     def right!

--- a/lib/active_recall/version.rb
+++ b/lib/active_recall/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecall
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
Apparently, `belongs_to :foo, polymorphic true` doesn't work with STI.